### PR TITLE
Fix regression in building app procedure

### DIFF
--- a/app/app.R
+++ b/app/app.R
@@ -36,6 +36,7 @@ library(tippy)
 
 # adam_data
 library(haven)
+library(cards)
 
 box::use(
   logic / adam_data[get_adsl, get_adas, get_adtte, get_adlb],

--- a/renv.lock
+++ b/renv.lock
@@ -369,6 +369,22 @@
       ],
       "Hash": "d7e13f49c19103ece9e58ad2d83a7354"
     },
+    "cards": {
+      "Package": "cards",
+      "Version": "0.1.0",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "cli",
+        "dplyr",
+        "glue",
+        "rlang",
+        "tidyr",
+        "tidyselect"
+      ],
+      "Hash": "9c4837e8ea64efc048919647b2a23041"
+    },
     "checkmate": {
       "Package": "checkmate",
       "Version": "2.3.2",


### PR DESCRIPTION
This PR solves what ended up being a very thorny issue. In PR #18 , I discovered that `shinylive::export()` for the app was failing due to what I thought was an issue with the `broom` package. After a rather lengthy debugging session in the internals of `shinylive`, the problem was the `cards` package (a dependency of `gtsummary`) was somehow lost in the `renv` lockfile. I've updated the app code to force a reference to cards, and have updated the lockfile accordingly.