### PR TITLE
Add support for pkglite

### DIFF
--- a/.github/scripts/copy-ectd-bundle.sh
+++ b/.github/scripts/copy-ectd-bundle.sh
@@ -7,8 +7,18 @@ function l { # Log a message to the terminal.
     echo -e "[$SCRIPT_NAME] ${1:-}"
 }
 
-# ECTD file to copy from source repo
+# Environment variables representing directory structure
+# - defined in specific GitHub Action step
+#DESTINATION_PROGRAMS_DIR=submissions-pilot4-webR-to-fda/m5/datasets/rconsortiumpilot4/analysis/adam/programs
+#DESTINATION_DATASETS_DIR=submissions-pilot4-webR-to-fda/m5/datasets/rconsortiumpilot4/analysis/adam/datasets
+#ADRG_DESTINATION_DIR=submissions-pilot4-webR-to-fda/m5/datasets/rconsortiumpilot4/analysis/adam/datasets
+#README_DESTINATION_DIR=submissions-pilot4-webR-to-fda
+#LETTER_DESTINATION_DIR: submissions-pilot4-webR-to-fda/m1/us
+#ECTD file to copy from source repo
+
+# Variables representing files/directories
 ECTD_BUNDLE_DIR=ectd_bundle
+ECTD_PKGLITE_FILE=pilot4_webR_pkglite.txt
 ECTD_BUNDLE_FILE=r4app.zip
 ADRG_SOURCE_DIR=adrg
 ADRG_SOURCE_FILE=adrg-quarto-pdf.pdf
@@ -19,6 +29,27 @@ README_DEST_FILE=README.md
 LETTER_SOURCE_DIR=cover-letter
 LETTER_SOURCE_FILE=cover-letter.pdf
 LETTER_DEST_FILE=cover-letter.pdf
+DATASETS_SOURCE_DIR=app/www/adam
+
+# Copy XPT datasets and metadata files
+if [ -f "${DATASETS_SOURCE_DIR}" ]; then
+  echo "Copy XPT data and metadata files"
+  if [ ! -f "${DESTINATION_DATASETS_DIR}" ]; then
+    echo "Create new directory ${DESTINATION_DATASETS_DIR}"
+    mkdir -p "${DESTINATION_DATASETS_DIR}"
+  fi
+  cp "${DATASETS_SOURCE_DIR}/*" "${DESTINATION_DATASETS_DIR}/."
+fi
+
+# Copy pkglite file
+if [ -f "${ECTD_PKGLITE_FILE}" ]; then
+  echo "Copy pkglite file"
+  if [ ! -f "${DESTINATION_PROGRAMS_DIR}" ]; then
+    echo "Create new directory ${DESTINATION_PROGRAMS_DIR}"
+    mkdir -p "${DESTINATION_PROGRAMS_DIR}"
+  fi
+  cp "${ECTD_PKGLITE_FILE}" "${DESTINATION_PROGRAMS_DIR}/."
+fi
 
 # Copy ADRG (PDF version)
 if [ -f "${ADRG_SOURCE_DIR}/${ADRG_SOURCE_FILE}" ]; then
@@ -55,14 +86,3 @@ if [ -f "${LETTER_SOURCE_DIR}/${LETTER_SOURCE_FILE}" ]; then
 fi
 
 echo "Cover letter copied to ${LETTER_DESTINATION_DIR}/${LETTER_DEST_FILE}"
-
-# if [ -f "${ECTD_BUNDLE_DIR}/${ECTD_BUNDLE_FILE}" ]; then
-#   echo "Copying ${ECTD_BUNDLE_DIR}/${ECTD_BUNDLE_FILE}"
-#   if [ ! -f "$DESTINATION_DIR" ]; then
-#     echo "Create new directory ${DESTINATION_DIR}"
-#     mkdir -p "${DESTINATION_DIR}"
-#   fi
-#   cp "${ECTD_BUNDLE_DIR}/${ECTD_BUNDLE_FILE}" "${DESTINATION_DIR}/${ECTD_BUNDLE_FILE}"
-# fi
-
-# echo "ECTD Bundle file copied to ${DESTINATION_DIR}/${ECTD_BUNDLE_FILE}"

--- a/.github/workflows/publish-ectd-bundle.yaml
+++ b/.github/workflows/publish-ectd-bundle.yaml
@@ -56,13 +56,20 @@ jobs:
         run: |
           quarto render cover-letter/cover-letter.qmd
 
+      - name: Compile pkglite file (custom)
+        run: |
+          source("utils.R"); create_pkglite_bundle();
+        shell: Rscript {0}
+
       - name: Compile ECTD Bundle (custom)
+        if: ${{ false }}
         run: |
           source("utils.R"); create_app_bundle(); create_ectd_bundle()
         shell: Rscript {0}
 
       - name: Set up object storage s3cmd cli tool
         uses: s3-actions/s3cmd@v1.6.1
+        if: ${{ false }}
         with:
           provider: linode
           region: 'us-east-1'
@@ -70,6 +77,7 @@ jobs:
           secret_key: ${{ secrets.S3_SECRET_KEY }}
 
       - name: Publish ECTD App bundle to Linode Object Storage
+        if: ${{ false }}
         run: |
           s3cmd put ectd_bundle/r4app.zip --mime-type 'application/zip' --acl-public s3://rsubmission-draft/r4app.zip
 
@@ -83,7 +91,8 @@ jobs:
       - name: Copy ECTD bundle
         run: bash ./.github/scripts/copy-ectd-bundle.sh
         env:
-          DESTINATION_DIR: submissions-pilot4-webR-to-fda/m5/datasets/rconsortiumpilot4/analysis/adam/programs
+          DESTINATION_PROGRAMS_DIR: submissions-pilot4-webR-to-fda/m5/datasets/rconsortiumpilot4/analysis/adam/programs
+          DESTINATION_DATASETS_DIR: submissions-pilot4-webR-to-fda/m5/datasets/rconsortiumpilot4/analysis/adam/datasets
           ADRG_DESTINATION_DIR: submissions-pilot4-webR-to-fda/m5/datasets/rconsortiumpilot4/analysis/adam/datasets
           README_DESTINATION_DIR: submissions-pilot4-webR-to-fda
           LETTER_DESTINATION_DIR: submissions-pilot4-webR-to-fda/m1/us

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ ectd_bundle/*
 !ectd_bundle/README.md
 app_bundle/*
 !app_bundle/README.md
+pilot4_webR_files/
+pilot4_webR_pkglite.txt

--- a/app/DESCRIPTION
+++ b/app/DESCRIPTION
@@ -1,0 +1,1 @@
+Package: pilot4webR

--- a/app/app.R
+++ b/app/app.R
@@ -36,7 +36,6 @@ library(tippy)
 
 # adam_data
 library(haven)
-library(cards)
 
 box::use(
   logic / adam_data[get_adsl, get_adas, get_adtte, get_adlb],

--- a/ectd_readme/README.qmd
+++ b/ectd_readme/README.qmd
@@ -13,14 +13,6 @@ The objective of the R Consortium R submission Pilot 4 Project is to test the co
 
 To learn more about other pilots, visit [the R consortium R submission working group website](https://rconsortium.github.io/submissions-wg/) and the [R consortium working group page](https://www.r-consortium.org/projects/isc-working-groups).
 
-## Instructions for Electronic Gateway Transfer
-
-Due to a limitation on file size imposed by GitHub, this repostitory does not include the pilot 4 pre-compiled application file `r4app.zip`. Please use the following procedure to prepare the local clone of this repository for the electronic gateway transfer:
-
-1. Clone this repository to your local machine or download the ZIP archive of the repostory using <https://github.com/RConsortium/submissions-pilot4-webR-to-fda/archive/refs/heads/main.zip> and extract to your local machine. 
-2. Create a new directory called `programs` in the `m5/datasets/rconsortiumpilot4/analysis/adam/` directory.
-3. Download the `r4app.zip` archive from [this link](https://rsubmission-draft.us-east-1.linodeobjects.com/r4app.zip) and save it to the `m5/datasets/rconsortiumpilot4/analysis/adam/programs/` directory.
-
 ## FDA Response 
 
 - Initial submission
@@ -62,7 +54,7 @@ m5
                 │   ├── define.xml        # ADaM data define file
                 │   └── define2-0-0.xsl
                 └── programs
-                    ├── r4app.zip         # Pre-compiled application in zip archive
+                    ├── pilot4_webR_pkglite.txt         # pkglite bundle
 ```
 Other files: (**Do not include in eCTD package**)
 
@@ -71,7 +63,7 @@ Other files: (**Do not include in eCTD package**)
 
 ## News
 
-The ECTD bundle and associated compiled application archive were last rendered on {{< meta date >}} .
+The ECTD bundle was last rendered on {{< meta date >}} .
 
 ## Questions 
 

--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.4.1",
+    "Version": "4.4.3",
     "Repositories": [
       {
         "Name": "BioCsoft",
@@ -369,22 +369,6 @@
       ],
       "Hash": "d7e13f49c19103ece9e58ad2d83a7354"
     },
-    "cards": {
-      "Package": "cards",
-      "Version": "0.1.0",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Requirements": [
-        "R",
-        "cli",
-        "dplyr",
-        "glue",
-        "rlang",
-        "tidyr",
-        "tidyselect"
-      ],
-      "Hash": "9c4837e8ea64efc048919647b2a23041"
-    },
     "checkmate": {
       "Package": "checkmate",
       "Version": "2.3.2",
@@ -561,7 +545,7 @@
     },
     "emmeans": {
       "Package": "emmeans",
-      "Version": "1.10.3",
+      "Version": "1.11.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -574,7 +558,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "276510e85e99a058fa4a0668e7ecca05"
+      "Hash": "80fa277f6bb5d98d0889fa33930f0b56"
     },
     "estimability": {
       "Package": "estimability",
@@ -1415,6 +1399,19 @@
       ],
       "Hash": "015473b3c114c47a50282be0dbe80ad4"
     },
+    "pkglite": {
+      "Package": "pkglite",
+      "Version": "0.2.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "crayon",
+        "magrittr",
+        "remotes"
+      ],
+      "Hash": "df9aa0563aeace822cd7c564b25ebdbd"
+    },
     "prettyunits": {
       "Package": "prettyunits",
       "Version": "1.2.0",
@@ -1551,6 +1548,20 @@
         "vroom"
       ],
       "Hash": "9de96463d2117f6ac49980577939dfb3"
+    },
+    "remotes": {
+      "Package": "remotes",
+      "Version": "2.5.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "methods",
+        "stats",
+        "tools",
+        "utils"
+      ],
+      "Hash": "3ee025083e66f18db6cf27b56e23e141"
     },
     "renv": {
       "Package": "renv",

--- a/utils.R
+++ b/utils.R
@@ -28,7 +28,7 @@ build_app <- function(dir_source = "app", dir_build = "_site", overwrite = TRUE)
     fs::file_move(temp_dir_source_www, temp_dir_www) # Move www out for shinylive::export to work cleanly
   }
 
-  shinylive::export(temp_dir_source, temp_dir_out, verbose = FALSE, wasm_packages = TRUE)
+  shinylive::export(temp_dir_source, temp_dir_out, quiet = FALSE, wasm_packages = FALSE)
   if (fs::dir_exists(temp_dir_www)) {
     fs::dir_walk(temp_dir_www, \(f) fs::file_move(f, temp_dir_out))
   }
@@ -113,4 +113,60 @@ extract_app_bundle <- function(archive_name = "shinyapp.zip", dir_build = "_site
     dir = "."
   )
   invisible(TRUE)
+}
+
+create_pkglite_bundle <- function(source_app_dir = "app", pkglite_file = "pilot4_webR_pkglite.txt") {
+  # application source code
+  pkg <- source_app_dir
+
+  pkg |>
+    pkglite::collate(
+      # logic R scripts
+      pkglite::file_spec(
+        path = "logic/",
+        format = "text",
+        pattern = "*.R$",
+        recursive = TRUE
+      ),
+      # view R scripts
+      pkglite::file_spec(
+        path = "views/",
+        format = "text",
+        pattern = "*.R",
+        recursive = TRUE
+      ),
+      # png images
+      pkglite::file_spec(
+        path = "www/static",
+        format = "binary",
+        pattern = "*.png$",
+        recursive = TRUE
+      ),
+      # svg and other web asset files
+      pkglite::file_spec(
+        path = "www/static",
+        format = "text",
+        pattern = "*.svg$|*.md$|*.css$|*.js$",
+        recursive = TRUE
+      ),
+      # index html page
+      pkglite::file_spec(
+        path = "www/",
+        format = "text",
+        pattern = "index.html",
+        recursive = FALSE
+      ),
+      # app.R file
+      pkglite::file_spec(
+        path = ".",
+        format = "text",
+        pattern = "app.R",
+        recursive = FALSE
+      )
+    ) |>
+    pkglite::pack(output = pkglite_file, quiet = FALSE)
+}
+
+unpack_pkglite_bundle <- function(pkglite_file = "pilot4_webR_pkglite.txt", output_dir = "pilot4_webR_files") {
+  pkglite::unpack(input = pkglite_file, output = output_dir)
 }


### PR DESCRIPTION
This PR integrates `{pkglite}` to create the application bundle. After feedback from the initial FDA review, the use of the `.zip` archive for bundling the application source files did not conform to the ECTD guidelines, as that zip archive contained additional file types (javascript, css) that are not on the approved file list. Using `{pkglite}` creates the application bundle as a text file, which is approved and was used in Pilot 2.